### PR TITLE
Make errors go away 3

### DIFF
--- a/install/install_win.js
+++ b/install/install_win.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 
 module.exports = function(){
 
-	var args = JSON.parse(process.env.npm_config_argv).original;
+	var args = process.env.npm_config_argv ? JSON.parse(process.env.npm_config_argv).original : [];
 	var test = new RegExp('^-.*$', 'g');
 
 	var flags = args.filter(function(value) {

--- a/install/install_win.js
+++ b/install/install_win.js
@@ -1,12 +1,3 @@
-const fs = require('fs');
-const inquirer = require('inquirer');
-const dotenv = require('dotenv');
-
 module.exports = function(){
-	makeEnv("edge");
 };
-
-function makeEnv(pack) {
-	fs.writeFileSync(fs.realpathSync(__dirname + '\\..') + "\\.env", `NNP_PACKAGE=${pack}`);
-}
 

--- a/install/install_win.js
+++ b/install/install_win.js
@@ -3,67 +3,10 @@ const inquirer = require('inquirer');
 const dotenv = require('dotenv');
 
 module.exports = function(){
-
-	var args = process.env.npm_config_argv ? JSON.parse(process.env.npm_config_argv).original : [];
-	var test = new RegExp('^-.*$', 'g');
-
-	var flags = args.filter(function(value) {
-		return test.test(value);
-	});
-
-	if (flags.includes('-p') || flags.includes('--production')) {
-		dotenv.config({path: fs.realpathSync(__dirname + '/../.env')});
-		if (process.env.NNP_PACKAGE) {
-			return;
-		} else {
-			console.error('It has been used flag -p but no package has been specified during dev installation.\nAborting.');
-			process.exit(1);
-		}
-	}
-
-	var pattern = new RegExp(".*edge.*", "gi");
-	var choices;
-
-	try {
-		choices = fs.readdirSync(__dirname + "/../../");
-	} catch (error) {}
-
-	if (choices) {
-		choices = choices.filter(value => {
-			return pattern.test(value);
-		});
-
-		choices.push('Not listed');
-
-		inquirer.prompt([{
-			type: 'list',
-			name: 'package',
-			message: 'Which package do you want to use?',
-			choices
-		}])
-		.then(answer => {
-			if (answer.package === 'Not listed') {
-				return manuallyInsert();
-			}
-
-			makeEnv(answer.package);
-		});
-	} else {
-		manuallyInsert();
-	}
-
+	makeEnv("edge");
 };
 
 function makeEnv(pack) {
 	fs.writeFileSync(fs.realpathSync(__dirname + '\\..') + "\\.env", `NNP_PACKAGE=${pack}`);
 }
 
-function manuallyInsert() {
-	inquirer.prompt([{
-		type: 'input',
-		name: 'package',
-		message: "Type the name of the package you want to use:\n"
-	}]).then(answer => {
-		makeEnv(answer.package)
-	});
-}

--- a/src/windows_printer.js
+++ b/src/windows_printer.js
@@ -4,7 +4,7 @@ const os = require('os');
 
 dotenv.config({path: fs.realpathSync(__dirname + '/../.env')});
 
-const edge = require(`../../${process.env.NNP_PACKAGE}`);
+const edge = require('electron-edge-js');
 const dllPath = fs.realpathSync(__dirname + '/../lib/windows/windows_printer.dll').replace('.asar', '.asar.unpacked');
 
 module.exports = class WinPrinter{


### PR DESCRIPTION
This removes the interactive install process and hardcodes a `require` to the only edge implementation that we're going to use (electron-edge-js).